### PR TITLE
Group several parsers' messages

### DIFF
--- a/pdf/config.json5
+++ b/pdf/config.json5
@@ -150,6 +150,10 @@
             parse: {
                 type: 'regex-counter',
                 stdstar: {
+                    '^\\s*(/opt|/lib|[#]FailureMessage).*$': {
+                        nameGroup: 'stack trace collapsed'
+                    },
+
                     '^.*$': {
                         nameReplace: {'[0-9]': ''},
                     },
@@ -163,6 +167,14 @@
             parse: {
                 type: 'regex-counter',
                 stderr: {
+                    '^\\s*(Syntax Warning: Could not parse ligature component).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(Syntax Error: Unknown character collection).*$': {
+                        nameGroup: 1
+                    },
+
                     '.*': {
                         nameReplace: {'[0-9]': ''},
                     },
@@ -176,6 +188,14 @@
             parse: {
                 type: 'regex-counter',
                 stdstar: {
+                    '^\\s*(Syntax Warning: Could not parse ligature component).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(Syntax Error: Unknown character collection).*$': {
+                        nameGroup: 1
+                    },
+
                     '^.*$': {
                         nameReplace: {'[0-9]': ''},
                     },
@@ -243,6 +263,14 @@
                     // Copy errors without numbers...
                     '^ERROR: .*': {
                         nameReplace: {'[0-9]': ''},
+                    },
+
+                    '^(WARNING: error decoding stream data for object).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^(WARNING: operation for dictionary attempted on object of type).*$': {
+                        nameGroup: 1
                     },
 
                     // Copy warnings without numbers....
@@ -327,6 +355,10 @@
                         nameGroup: 'PDF Header',
                     },
 
+                    '^Date.*$': {
+                        nameGroup: 'Date',
+                    },
+
                     '^(.*?[Ee]ntropy.*):\\s*(\\d\\.\\d+)\\s+\\(\\s*(\\d+) bytes\\)$': {
                         nameGroup: 1,
                         countGroup: 2,
@@ -361,7 +393,7 @@
           version: 'schizo-test53',
           parse: {
             type: 'regex-counter',
-            stdstar: {
+            stdout: {
               '^Max RMSE: (.*)': {
                 nameGroup: 'Max RMSE',
                 countGroup: 1,
@@ -376,6 +408,11 @@
                 nameReplace: {
                   '[0-9]': '',
                 },
+              },
+            },
+            stderr: {
+              '^.*$': {
+                nameGroup: 'ERROR'
               },
             },
           },
@@ -401,6 +438,34 @@
                     },
                 },
                 stderr: {
+                    '^\\s*(PDF error : Lexing error).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(PDF error : The same name appears several times in dict).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(PDF error : Unexpected command).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(PDF error : Xref table contains object).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(Type error : Inconsistent type inference).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(Type error : Invalid variant type).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(Type error : Unexpected entry).*$': {
+                        nameGroup: 1
+                    },
+
                     '.*': {
                         nameReplace: {
                             '0x[0-9a-f]+b?|[0-9]': '',
@@ -430,6 +495,34 @@
                     },
                 },
                 stderr: {
+                    '^\\s*(PDF error : Lexing error).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(PDF error : The same name appears several times in dict).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(PDF error : Unexpected command).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(PDF error : Xref table contains object).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(Type error : Inconsistent type inference).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(Type error : Invalid variant type).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(Type error : Unexpected entry).*$': {
+                        nameGroup: 1
+                    },
+
                     '.*': {
                         nameReplace: {
                             '0x[0-9a-f]+b?|[0-9]': '',
@@ -446,6 +539,34 @@
                 type: 'regex-counter',
                 stdout: {},
                 stderr: {
+                    '^\\s*(error: cannot create appearance stream).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(error: unknown colorspace).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(error: zlib error: invalid).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(warning: cannot create ToUnicode mapping).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(warning: ignoring one to many mapping in cmap).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(warning: non-embedded font using identity encoding).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(warning: non-page object in page tree).*$': {
+                        nameGroup: 1
+                    },
+
                     '^.*$': {
                         nameReplace: {'[0-9]': ''},
                     },
@@ -461,6 +582,34 @@
                 type: 'regex-counter',
                 stdout: {},
                 stderr: {
+                    '^\\s*(error: cannot create appearance stream).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(error: unknown colorspace).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(error: zlib error: invalid).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(warning: cannot create ToUnicode mapping).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(warning: ignoring one to many mapping in cmap).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(warning: non-embedded font using identity encoding).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(warning: non-page object in page tree).*$': {
+                        nameGroup: 1
+                    },
+
                     '^.*$': {
                         nameReplace: {'[0-9]': ''},
                     },
@@ -490,6 +639,35 @@
                 countGroup: 1,
                 countAsNumber: true,
               },
+
+              '^\\s*(error: cannot create appearance stream).*$': {
+                  nameGroup: 1
+              },
+
+              '^\\s*(error: unknown colorspace).*$': {
+                  nameGroup: 1
+              },
+
+              '^\\s*(error: zlib error: invalid).*$': {
+                  nameGroup: 1
+              },
+
+              '^\\s*(warning: cannot create ToUnicode mapping).*$': {
+                  nameGroup: 1
+              },
+
+              '^\\s*(warning: ignoring one to many mapping in cmap).*$': {
+                  nameGroup: 1
+              },
+
+              '^\\s*(warning: non-embedded font using identity encoding).*$': {
+                  nameGroup: 1
+              },
+
+              '^\\s*(warning: non-page object in page tree).*$': {
+                  nameGroup: 1
+              },
+
               '.*': {
                 nameGroup: '',
               },
@@ -504,6 +682,34 @@
                 type: 'regex-counter',
                 stdout: {},
                 stderr: {
+                    '^\\s*(error: cannot create appearance stream).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(error: unknown colorspace).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(error: zlib error: invalid).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(warning: cannot create ToUnicode mapping).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(warning: ignoring one to many mapping in cmap).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(warning: non-embedded font using identity encoding).*$': {
+                        nameGroup: 1
+                    },
+
+                    '^\\s*(warning: non-page object in page tree).*$': {
+                        nameGroup: 1
+                    },
+
                     '^.*$': {
                         nameReplace: {'[0-9]': ''},
                     },

--- a/pdf/config.json5
+++ b/pdf/config.json5
@@ -151,7 +151,7 @@
                 type: 'regex-counter',
                 stdstar: {
                     '^\\s*(/opt|/lib|[#]FailureMessage).*$': {
-                        nameGroup: 'stack trace collapsed'
+                        nameGroup: '<<workbench: stack trace collapsed>>'
                     },
 
                     '^.*$': {
@@ -355,10 +355,6 @@
                         nameGroup: 'PDF Header',
                     },
 
-                    '^Date.*$': {
-                        nameGroup: 'Date',
-                    },
-
                     '^(.*?[Ee]ntropy.*):\\s*(\\d\\.\\d+)\\s+\\(\\s*(\\d+) bytes\\)$': {
                         nameGroup: 1,
                         countGroup: 2,
@@ -412,7 +408,7 @@
             },
             stderr: {
               '^.*$': {
-                nameGroup: 'ERROR'
+                nameGroup: '<<workbench: collapsed errors>>'
               },
             },
           },


### PR DESCRIPTION
Reduce the number of messages displayed in the FAW by truncating, grouping, and eliminating some PDF parser message output lines.