### PR TITLE
Optionally allow 'decision_default' to be loaded from a file

### DIFF
--- a/pdf/config.json5
+++ b/pdf/config.json5
@@ -107,6 +107,8 @@
       // See ml_test/config.json5 for example.
     },
 
+    // May also specify a plaintext file to avoid needed to format as JSON5:
+    // decision_default: {file: 'file_path_relative_to_config.json5'},
     decision_default: '\
 # Any line beginning with a hash is a comment.  \n\
 filters:  \n\

--- a/workbench.py
+++ b/workbench.py
@@ -12,6 +12,7 @@ import dataclasses
 import hashlib
 import io
 import os
+import pathlib
 import re
 import shlex
 import shutil
@@ -512,7 +513,13 @@ def _check_config_file(config, build_dir):
                 },
         }),
         s.Optional('parserDefaultTimeout', default=30): s.Or(float, int),
-        'decision_default': str,
+        'decision_default': s.Or(
+            str,
+            s.And(
+                {'file': str},
+                s.Use(lambda x: pathlib.Path(os.path.join(CONFIG_FOLDER, x['file'])).read_text())
+            )
+        ),
         s.Optional('pipelines', default={}): s.Or({}, {
             s.And(str, lambda x: '_' not in x and '.' not in x,
                     error='Must not have underscore or dot'): {


### PR DESCRIPTION
Optionally allow `decision_default` to be loaded from a file instead of always embedding it directly in the file. To support loading from a file, set the key the `decision_default` to something like this:
```json5
  decision_default: { file: '<file path>' }
```  

If the `<file path>` is relative, it is interpreted relative to the config directory.