### PR TITLE
Update to xpdf 4.04

### DIFF
--- a/pdf/parser-xpdf/config.json5
+++ b/pdf/parser-xpdf/config.json5
@@ -256,11 +256,11 @@
                 commands: [
                     'RUN mkdir -p /opt/xpdf \
                         && cd /opt/xpdf \
-                        && wget https://dl.xpdfreader.com/xpdf-tools-linux-4.03.tar.gz \
-                        && tar xf xpdf-tools-linux-4.03.tar.gz \
-                        && rm xpdf-tools-linux-4.03.tar.gz \
+                        && wget https://dl.xpdfreader.com/xpdf-tools-linux-4.04.tar.gz \
+                        && tar xf xpdf-tools-linux-4.04.tar.gz \
+                        && rm xpdf-tools-linux-4.04.tar.gz \
                         && mv */* ./ \
-                        && rm -rf xpdf-tools-linux-4.03 \
+                        && rm -rf xpdf-tools-linux-4.04 \
                         ',
                 ],
            },


### PR DESCRIPTION
The prior version of xpdf is no longer available from the downloads page, so the Docker build of the FAW fails.