### PR TITLE
Support adding extra features from DSL

### DIFF
--- a/faw/pdf-observatory/ci/index.ts
+++ b/faw/pdf-observatory/ci/index.ts
@@ -3,8 +3,8 @@
 import { readFileSync, writeFile } from 'fs'
 import { stdin as input, stdout as output, argv } from 'process'
 
-import { DslResult, DslExpression, dslParser } from './common/dsl'
-import { FileFilterData, reprocess } from './common/processor';
+import { DslResult, dslParser } from './common/dsl'
+import { reprocess } from './common/processor';
 
 //Parse the incoming data in to JSON and check for keys
 // Do this safely, per https://stackoverflow.com/a/40363010/160205
@@ -61,7 +61,7 @@ streamToPromise(input).then((inputData: any) => {
 
   //Reprocess decisions
   console.error('Reprocessing decisions ...');
-  var decisions = reprocess(dsl, pdfGroups)
+  var decisions = reprocess(dsl, pdfGroups).decisions;
   console.error('Reprocessing decisions ... Completed');
 
   //Write it out

--- a/faw/pdf-observatory/ci/index.ts
+++ b/faw/pdf-observatory/ci/index.ts
@@ -67,7 +67,7 @@ streamToPromise(input).then((inputData: any) => {
   //Write it out
   var result = JSON.stringify(decisions);
   console.error('Streaming out decisions ...');
-  writeFile(output.fd, result, (err) => {
+  output.write(result, (err) => {
     if (err) throw err;
     console.error('Streaming out decisions ... Completed');
   });

--- a/faw/pdf-observatory/common/dsl.ts
+++ b/faw/pdf-observatory/common/dsl.ts
@@ -12,14 +12,12 @@ export interface DslResult {
 
 export interface DslExtraFeature {
   featureText: string;
-  all: boolean;
   caseInsensitive: boolean;
   patterns: Array<DslFilterPattern>;
 }
 
 export interface DslFilter {
   name: string;
-  all: boolean;
   caseInsensitive: boolean;
   patterns: Array<DslFilterPattern>;
 }
@@ -98,23 +96,23 @@ function generateDslParser() {
           return { caseInsensitive: true }; }
 
       extra_features_def
-        = INDENT_CHECK featureText:feature_text re:regex_flags all:(WS "all")? ":"
+        = INDENT_CHECK featureText:feature_text re:regex_flags ":"
             WS_LINES
             &{ return indentPush(); }
             inner:(INDENT filters_pattern+)?
             &{ indentPop(); return inner; } {
-              return { featureText: featureText, all: !!all, caseInsensitive: !!re.caseInsensitive, patterns: inner[1] }; }
+              return { featureText: featureText, caseInsensitive: !!re.caseInsensitive, patterns: inner[1] }; }
 
       feature_text
         = $[A-Za-z0-9_\\-=+<>()\\[\\],.?; ]+
 
       filters_def
-        = INDENT_CHECK name:filter_name re:regex_flags all:(WS "all")? ":"
+        = INDENT_CHECK name:filter_name re:regex_flags ":"
             WS_LINES
             &{ return indentPush(); }
             inner:(INDENT filters_pattern+)?
             &{ indentPop(); return inner; } {
-              return { name: name, all: !!all, caseInsensitive: !!re.caseInsensitive, patterns: inner[1] }; }
+              return { name: name, caseInsensitive: !!re.caseInsensitive, patterns: inner[1] }; }
 
       filter_name
         = leader:[A-Z] trailer:ID_CHARS { return leader + trailer; }

--- a/faw/pdf-observatory/common/dsl.ts
+++ b/faw/pdf-observatory/common/dsl.ts
@@ -5,14 +5,22 @@ import peg from 'pegjs';
 export const dslDefault = `# Loading...`;
 
 export interface DslResult {
+  extraFeatures: Array<DslExtraFeature>;
   filters: Array<DslFilter>;
   outputs: Map<string, DslOutput>;
+}
+
+export interface DslExtraFeature {
+  featureText: string;
+  all: boolean;
+  caseInsensitive: boolean;
+  patterns: Array<DslFilterPattern>;
 }
 
 export interface DslFilter {
   name: string;
   all: boolean;
-  caseInsensitive?: boolean;
+  caseInsensitive: boolean;
   patterns: Array<DslFilterPattern>;
 }
 
@@ -65,11 +73,20 @@ function generateDslParser() {
       }
 
       start
-        = WS_INIT filters:filters_expr WS_LINES outputs:outputs_expr WS_LINES WS_MAYBE COMMENT?
-            { return { filters: filters, outputs: outputs }; }
+        = WS_INIT extraFeatures:extra_features_expr WS_LINES filters:filters_expr WS_LINES outputs:outputs_expr WS_LINES WS_MAYBE COMMENT?
+            { return { extraFeatures: extraFeatures, filters: filters, outputs: outputs }; }
+
+      extra_features_expr
+        = (
+            "features:" WS_LINES
+            &{ return indentPush(); }
+            inner:(INDENT extra_features_def+)?
+            &{ indentPop(); return inner; }
+            { return inner[1]; }
+          ) / ( "" { return []; } )
 
       filters_expr
-        = "filters:" WS_LINES &{ return indentPush(); } inner:(INDENT filters_defs+)? &{ indentPop(); return inner; }
+        = "filters:" WS_LINES &{ return indentPush(); } inner:(INDENT filters_def+)? &{ indentPop(); return inner; }
             { return inner[1]; }
 
       regex_flags
@@ -78,17 +95,26 @@ function generateDslParser() {
 
       regex_flag
         = "i" {
-          return {caseInsensitive: true}; }
+          return { caseInsensitive: true }; }
 
-      filters_defs
+      extra_features_def
+        = INDENT_CHECK featureText:feature_text re:regex_flags all:(WS "all")? ":"
+            WS_LINES
+            &{ return indentPush(); }
+            inner:(INDENT filters_pattern+)?
+            &{ indentPop(); return inner; } {
+              return { featureText: featureText, all: !!all, caseInsensitive: !!re.caseInsensitive, patterns: inner[1] }; }
+
+      feature_text
+        = $[A-Za-z0-9_\\-=+<>()\\[\\],.?; ]+
+
+      filters_def
         = INDENT_CHECK name:filter_name re:regex_flags all:(WS "all")? ":"
             WS_LINES
             &{ return indentPush(); }
             inner:(INDENT filters_pattern+)?
             &{ indentPop(); return inner; } {
-              let r = { name: name, all: !!all, patterns: inner[1] };
-              if (re.caseInsensitive) r.caseInsensitive = true;
-              return r; }
+              return { name: name, all: !!all, caseInsensitive: !!re.caseInsensitive, patterns: inner[1] }; }
 
       filter_name
         = leader:[A-Z] trailer:ID_CHARS { return leader + trailer; }

--- a/faw/pdf-observatory/common/processor.ts
+++ b/faw/pdf-observatory/common/processor.ts
@@ -173,18 +173,17 @@ export function reprocess(
         if (r.pat.test(message)) {
           // Do we need to constrain the matching set based on an auxiliary
           // check?
-          if (r.check !== null) {
-            const group = evalCheck(message, r.check);
-            if (group.size > 0) {
-              // Merge `group` into `filesSubset`
-              group.forEach(filesSubset.add, filesSubset);
-            }
-          } else {
+          if (r.check === null) {
             // Accept all matches; short-circuit
             for (const [fileIndex, ] of files) {
               filesSubset.add(fileIndex);
             }
             break;
+          }
+          const group = evalCheck(message, r.check);
+          if (group.size > 0) {
+            // Merge `group` into `filesSubset`
+            group.forEach(filesSubset.add, filesSubset);
           }
         }
       }

--- a/faw/pdf-observatory/common/processor.ts
+++ b/faw/pdf-observatory/common/processor.ts
@@ -1,78 +1,87 @@
-import { DslResult, DslExpression } from './dsl'
+import { DslResult, DslExpression, DslFilterPattern } from './dsl'
 import { PdfDecision } from './common';
 
-/* These exports should go in to a different file */
 export type PdfGroups = {
+  /*
+   * message - string output from a parser (may be post-processed)
+   * Values are pairs:
+   *    1. Index into `files` of file that produced this message
+   *    2. Numeric feature value, or 1 for binary features
+   */
   groups: {[message: string]: Array<[number, number]>},
+  /*
+   * File names
+   */
   files: Array<string>
 };
 
-export type FileFilterData = {
-  name: string,
-  skipped: boolean,
-  files: Set<string>,
-};
+export type ReprocessResult = {
+  decisions: PdfDecision[],
+  extraFeaturesByFile: Map<string, string[]>,
+}
 
-
-export function reprocess(decisionDefinition: DslResult, reprocessPdfGroups: PdfGroups): PdfDecision[] 
-{ 
-  // Build file list
-  const newPdfs = [];
-  const pdfMap = new Map<number, PdfDecision>();
+export function reprocess(
+  decisionDefinition: DslResult,
+  reprocessPdfGroups: PdfGroups
+): ReprocessResult {
+  // Build file list first
+  const newDecisions: Array<PdfDecision> = [];
+  const decisionsByFileIndex = new Map<number, PdfDecision>();
   for (const [, files] of Object.entries(reprocessPdfGroups.groups)) {
-    for (const f of files) {
-      if (pdfMap.has(f[0])) continue;
-      const dec = {
-            testfile: reprocessPdfGroups.files[f[0]],
-            info: [],
+    for (const [fileIndex, featureValue] of files) {
+      if (decisionsByFileIndex.has(fileIndex)) continue;
+      const decision: PdfDecision = {
+        testfile: reprocessPdfGroups.files[fileIndex],
+        info: [],
       };
-      newPdfs.push(dec);
-      pdfMap.set(f[0], dec);
+      newDecisions.push(decision);
+      decisionsByFileIndex.set(fileIndex, decision);
     }
   }
-  
+
   // Build sets of filter groups
-  const pdfGroups = new Map<string, Set<number>>();
-  const pdfGroupIsNegative = new Map<string, boolean>();
-  for (const f of decisionDefinition.filters) {
-    const result = new Set<number>();
-    pdfGroups.set(f.name, result);
+  const filesWithMessages = Object.entries(reprocessPdfGroups.groups);
 
-    if (f.all) {
-      pdfGroupIsNegative.set(f.name, true);
-    }
-    else {
-      pdfGroupIsNegative.set(f.name, false);
-    }
+  function fileIndicesMatchingFilter(
+    patterns: Array<DslFilterPattern>,
+    caseInsensitive: boolean,
+    // Only used for saving info
+    identifier: string,
+    conjunctive: boolean,
+  ): Set<number> {
+    const fileIndices = new Set<number>();
 
-    const rs = f.patterns.map(p => ({
-        pat: new RegExp(p.pat, f.caseInsensitive ? 'i' : undefined),
-        check: p.check,
+    const rules = patterns.map(p => ({
+      pat: new RegExp(p.pat, caseInsensitive ? 'i' : undefined),
+      check: p.check,
     }));
-    for (const [k, files] of Object.entries(reprocessPdfGroups.groups)) {
+    for (const [message, files] of filesWithMessages) {
       let matched = false;
       // Do any of our filter's patterns match this message?
       let filesSubset = files;
 
-      const evalCheck = (k: string, check: any): Set<number> => {
+      const evalCheck = (message: string, check: any): Set<number> => {
         const parts = new Map<string, Array<number>>();
-        for (const [id, suffix] of [['sum', '_sum'], ['nan', '_nan'],
-            ['count', '']]) {
-          let filesWithMsg = reprocessPdfGroups.groups[k + suffix];
+        for (const [id, suffix] of [
+          ['sum', '_sum'],
+          ['nan', '_nan'],
+          ['count', '']
+        ]) {
+          const filesWithMsg = reprocessPdfGroups.groups[message + suffix];
           if (filesWithMsg === undefined) {
-            if (['sum', 'nan'].indexOf(k.split('_').pop()!) !== -1) {
+            if (['sum', 'nan'].indexOf(message.split('_').pop()!) !== -1) {
               // If we can't find this, this is NOT a number, but likely a
               // subfield of a number (e.g., we're looking at _nan_sum)
               // So, act like no match.
               return new Set();
             }
-            throw new Error(`Could not find ${k + suffix}?`);
+            throw new Error(`Could not find ${message + suffix}?`);
           }
 
           const p = new Array<number>();
           parts.set(id, p);
-          for (const file of filesWithMsg) {
-            p[file[0]] = file[1];
+          for (const [fileIndex, featureValue] of filesWithMsg) {
+            p[fileIndex] = featureValue;
           }
         }
 
@@ -150,12 +159,12 @@ export function reprocess(decisionDefinition: DslResult, reprocessPdfGroups: Pdf
         return new Set(r.map((x, i) => [x, i]).filter(x => !!x[0]).map(x => x[1]));
       };
 
-      for (const r of rs) {
-        if (r.pat.test(k)) {
+      for (const r of rules) {
+        if (r.pat.test(message)) {
           // Do we need to constrain the matching set based on an auxiliary
           // check?
           if (r.check !== null) {
-            const group = evalCheck(k, r.check);
+            const group = evalCheck(message, r.check);
             if (group.size > 0) filesSubset = filesSubset.filter(x => group.has(x[0]));
             else continue;
           }
@@ -163,67 +172,103 @@ export function reprocess(decisionDefinition: DslResult, reprocessPdfGroups: Pdf
           break;
         }
       }
-
-      if (f.all) {
-        // If we're matching all, then we want to note the set of PDFs for
-        // which any message did not match.
-        if (!matched) {
-          for (const file of filesSubset) {
-            result.add(file[0]);
-            pdfMap.get(file[0])!.info.push(`'${f.name}' rejected '${k}'`);
-          }
+      if (matched) {
+        for (const [fileIndex, featureValue] of filesSubset) {
+          fileIndices.add(fileIndex);
         }
       }
-      else {
+      if (conjunctive && !matched) {
+        // If we're matching all, then we want to note the set of PDFs for
+        // which any message did not match.
+        for (const [fileIndex, ] of filesSubset) {
+          decisionsByFileIndex.get(fileIndex)!.info.push(`'${identifier}' rejected '${message}'`);
+        }
+      }
+      else if (matched) {
         // If we're matching any, then we're interested in PDFs where any
         // message did match.
-        if (matched) {
-          for (const file of filesSubset) {
-            result.add(file[0]);
-            pdfMap.get(file[0])!.info.push(`'${f.name}' accepted '${k}'`);
-          }
+        for (const [fileIndex, ] of filesSubset) {
+          decisionsByFileIndex.get(fileIndex)!.info.push(`'${identifier}' accepted '${message}'`);
         }
       }
     }
+    return fileIndices;
   }
 
-  // Apply DSL expressions to fill in status
-  for (const [f, dec] of pdfMap.entries()) {
+  const fileIndicesByExtraFeatureText = new Map<string, Set<number>>();
+  for (const extraFeature of decisionDefinition.extraFeatures) {
+    const fileIndices = fileIndicesMatchingFilter(
+      extraFeature.patterns,
+      extraFeature.caseInsensitive,
+      extraFeature.featureText,
+      extraFeature.all,
+    );
+    fileIndicesByExtraFeatureText.set(
+      extraFeature.featureText, fileIndices
+    );
+  }
+
+  // Add the new messages so that filters can use them
+  for (const [featureText, fileIndices] of fileIndicesByExtraFeatureText.entries()) {
+    filesWithMessages.push([featureText, Array.from(fileIndices, fileIndex => [fileIndex, 1])]);
+  }
+
+  const fileIndicesByFilterName = new Map<string, Set<number>>();
+  for (const filter of decisionDefinition.filters) {
+    const fileIndices = fileIndicesMatchingFilter(
+      filter.patterns, filter.caseInsensitive, filter.name, filter.all
+    );
+    fileIndicesByFilterName.set(filter.name, fileIndices);
+  }
+
+  // Populate decision objects with filter results (boolean) and outputs (string)
+  for (const [fileIndex, decision] of decisionsByFileIndex.entries()) {
     const evalExpr = (node: DslExpression): boolean => {
       if (node.type === 'else') return true;
       if (node.type === 'not') return !evalExpr(node.id1);
       if (node.type === 'and') return evalExpr(node.id1) && evalExpr(node.id2);
       if (node.type === 'or') return evalExpr(node.id1) || evalExpr(node.id2);
       if (node.type === 'id') {
-        let fileList = pdfGroups.get(node.id1);
+        let fileList = fileIndicesByFilterName.get(node.id1);
         if (fileList === undefined) {
           throw new Error(`Undefined filter ${node.id1}`);
         }
-
-        let r = fileList.has(f);
-        let not = pdfGroupIsNegative.get(node.id1);
-        if (not) r = !r;
-        return r;
+        return fileList.has(fileIndex);
       }
       throw new Error(`Unknown node type ${(node as any).type}`);
     };
 
-    for (const k of pdfGroups.keys()) {
-      dec[`filter-${k}`] = evalExpr({type: 'id', id1: k});
+    for (const k of fileIndicesByFilterName.keys()) {
+      decision[`filter-${k}`] = evalExpr({type: 'id', id1: k});
     }
 
     for (const [oname, ocases] of decisionDefinition.outputs.entries()) {
-      dec[oname] = 'unspecified';
+      decision[oname] = 'unspecified';
       for (const [value, expression] of ocases) {
         if (expression === null) continue;
 
         if (evalExpr(expression)) {
-          dec[oname] = value;
+          decision[oname] = value;
           break;
         }
       }
     }
   }
 
-  return newPdfs as unknown as PdfDecision[];
+  const extraFeaturesByFile = new Map<string, string[]>();
+  for (const [featureText, fileIndices] of fileIndicesByExtraFeatureText.entries()) {
+    for (const fileIndex of fileIndices) {
+      let extraFeatures = extraFeaturesByFile.get(reprocessPdfGroups.files[fileIndex]);
+      if (extraFeatures === undefined) {
+        extraFeatures = [];
+        extraFeaturesByFile.set(reprocessPdfGroups.files[fileIndex], extraFeatures);
+      }
+      extraFeatures.push(featureText);
+    }
+  }
+
+  return {
+    decisions: newDecisions,
+    extraFeaturesByFile: extraFeaturesByFile
+  };
 }

--- a/faw/pdf-observatory/common/processor.ts
+++ b/faw/pdf-observatory/common/processor.ts
@@ -74,7 +74,9 @@ export function reprocess(
               // So, act like no match.
               return new Set();
             }
-            throw new Error(`Could not find ${message + suffix}?`);
+            throw new Error(
+              `Could not evaluate check for \`${identifier}\` matching non-numeric message: ${message}`
+            );
           }
 
           const p = new Array<number>();
@@ -105,6 +107,11 @@ export function reprocess(
             const right = evalInner(check.id2);
             return left.map((l, i) => l >= right[i] ? 1 : 0);
           }
+          else if (check.type === '==') {
+            const left = evalInner(check.id1);
+            const right = evalInner(check.id2);
+            return left.map((l, i) => l == right[i] ? 1 : 0);
+          }
           else if (check.type === 'and') {
             const left = evalInner(check.id1);
             const right = evalInner(check.id2);
@@ -118,7 +125,10 @@ export function reprocess(
           else if (check.type === 'id') {
             const r = parts.get(check.id1);
             if (r === undefined) {
-              throw new Error(`No such numeric quantity? ${check.id1}`);
+              throw new Error(
+                `Could not evaluate check for ${identifier}: No such `
+                + `quantity ${check.id1} for message: ${message}`
+              );
             }
             return r;
           }
@@ -151,7 +161,9 @@ export function reprocess(
           }
 
           console.log(check);
-          throw new Error(`Check type ${check.type}`);
+          throw new Error(
+            `Could not evaluate check for ${identifier}: Unrecognized check type ${check.type}`
+          );
         };
 
         const r = evalInner(check);

--- a/faw/pdf-observatory/common/processor.ts
+++ b/faw/pdf-observatory/common/processor.ts
@@ -47,7 +47,6 @@ export function reprocess(
     caseInsensitive: boolean,
     // Only used for saving info
     identifier: string,
-    conjunctive: boolean,
   ): Set<number> {
     const fileIndices = new Set<number>();
 
@@ -173,22 +172,11 @@ export function reprocess(
         }
       }
       if (matched) {
-        for (const [fileIndex, featureValue] of filesSubset) {
-          fileIndices.add(fileIndex);
-        }
-      }
-      if (conjunctive && !matched) {
-        // If we're matching all, then we want to note the set of PDFs for
-        // which any message did not match.
-        for (const [fileIndex, ] of filesSubset) {
-          decisionsByFileIndex.get(fileIndex)!.info.push(`'${identifier}' rejected '${message}'`);
-        }
-      }
-      else if (matched) {
         // If we're matching any, then we're interested in PDFs where any
         // message did match.
         for (const [fileIndex, ] of filesSubset) {
           decisionsByFileIndex.get(fileIndex)!.info.push(`'${identifier}' accepted '${message}'`);
+          fileIndices.add(fileIndex);
         }
       }
     }
@@ -201,7 +189,6 @@ export function reprocess(
       extraFeature.patterns,
       extraFeature.caseInsensitive,
       extraFeature.featureText,
-      extraFeature.all,
     );
     fileIndicesByExtraFeatureText.set(
       extraFeature.featureText, fileIndices
@@ -216,7 +203,7 @@ export function reprocess(
   const fileIndicesByFilterName = new Map<string, Set<number>>();
   for (const filter of decisionDefinition.filters) {
     const fileIndices = fileIndicesMatchingFilter(
-      filter.patterns, filter.caseInsensitive, filter.name, filter.all
+      filter.patterns, filter.caseInsensitive, filter.name
     );
     fileIndicesByFilterName.set(filter.name, fileIndices);
   }

--- a/faw/pdf-observatory/common/tsconfig.json
+++ b/faw/pdf-observatory/common/tsconfig.json
@@ -24,7 +24,10 @@
       "dom",
       "dom.iterable",
       "scripthost"
-    ]
+    ],
+    "paths": {
+      "tslib" : ["../ui/node_modules/tslib/tslib.d.ts"]
+    },
   },
   "include": [
     "*.ts",

--- a/faw/pdf-observatory/faw_analysis_set_parse.py
+++ b/faw/pdf-observatory/faw_analysis_set_parse.py
@@ -19,7 +19,6 @@ import tempfile
 import threading
 import time
 import traceback
-from typing import Dict, Tuple, Union
 
 # Trickery to import pieces of pdf-etl decision pipeline
 import importlib

--- a/faw/pdf-observatory/faw_analysis_set_util.py
+++ b/faw/pdf-observatory/faw_analysis_set_util.py
@@ -3,7 +3,6 @@
 
 import collections
 import pymongo
-import sys
 
 PipelineParserSpec = collections.namedtuple('PipelineParserSpec', ['pipe',
         'parser', 'aset'])

--- a/faw/pdf-observatory/faw_pipelines.py
+++ b/faw/pdf-observatory/faw_pipelines.py
@@ -16,10 +16,8 @@ import functools
 import json
 import subprocess
 import time
-import traceback
 
 async def pipeline_admin(exit_flag, app_config, api_info, aset_id):
-    import asyncio
     loop = asyncio.get_running_loop()
     await loop.run_in_executor(None, _pipeline_admin, exit_flag, app_config, api_info, aset_id)
 

--- a/faw/pdf-observatory/faw_pipelines_util.py
+++ b/faw/pdf-observatory/faw_pipelines_util.py
@@ -7,10 +7,8 @@ from abc import ABCMeta, abstractmethod
 import contextlib
 import dataclasses
 import gridfs
-import json
 import motor.motor_asyncio as motor_asyncio
 import os
-import pymongo
 import subprocess
 import tempfile
 import urllib.request

--- a/faw/pdf-observatory/main.py
+++ b/faw/pdf-observatory/main.py
@@ -14,6 +14,7 @@ import collections
 import contextlib
 import functools
 import ujson as json
+import logging
 import mimetypes
 import motor.motor_asyncio
 import multiprocessing.connection
@@ -74,6 +75,8 @@ def main(pdf_dir, mongodb, host, port, hostname, in_docker, production, config,
 
     global app_config, app_config_path, app_docker, app_hostname, app_hostport, \
             app_init, app_mongodb, app_mongodb_conn, app_pdf_dir, app_production
+
+    logging.basicConfig()
 
     assert in_docker, 'Config specifying parsers must be in docker'
 

--- a/faw/pdf-observatory/main.py
+++ b/faw/pdf-observatory/main.py
@@ -29,6 +29,7 @@ import tempfile
 import time
 import traceback
 import vuespa
+from typing import Dict, Any, List
 
 app_config = None
 app_config_loaded = None
@@ -532,6 +533,12 @@ async def _init_check_pdfs():
 
 # A global cache for document information primarily for use by
 # `get_decisions` and `fetch_statsbyfile`.
+# Keys:
+#  (*option_kv, match_id)
+# Values:
+#  List of lists of dict, where the dict contains:
+#   "_id": filename
+#   feature text: 1 if present, 0 otherwise
 document_cache = cachetools.TTLCache(maxsize=100, ttl=5 * 60)
 
 
@@ -613,10 +620,7 @@ async def fetch_statsbyfile(options, match_id=None):
                  for k, v in option_kv]
     cache_key = (*option_kv, match_id)
 
-    try:
-        v = document_cache.get(cache_key)
-    except TypeError:
-        raise TypeError(cache_key)
+    v = document_cache.get(cache_key)
     if v is not None:
         if v[0] == fresh_key:
             # Cache data is up-to-date
@@ -771,9 +775,21 @@ class Client(vuespa.Client):
                 raise NotImplementedError(plugin_def['type'])
 
 
-    async def api_config_plugin_dec_run(self, plugin_key, api_url, json_args,
-            reference_decisions, subset_options):
+    async def api_config_plugin_dec_run(
+        self,
+        plugin_key: str,
+        api_url: str,
+        json_args: Dict[str, Any],
+        reference_decisions: List[Dict[str, Any]],
+        subset_options: Dict[str, Any],
+        extra_features_by_file: Dict[str, List[str]],
+    ):
         """Runs a decision plugin.
+
+        Args:
+            extra_features_by_file:
+                Mapping from filename to additional features derived
+                from parser output. May not be complete.
         """
         timer = _Timer()
 
@@ -855,12 +871,26 @@ class Client(vuespa.Client):
                                     # optimization, saves ~16% on large
                                     # collections
                                     bytes_written = 0
-                                    async for dd in self._statsbyfile_cursor(
+                                    async for dd in fetch_statsbyfile(
                                             subset_options):
                                         if bytes_written > 500e6:
                                             await s.drain()
                                             bytes_written = 0
                                         for d in dd:
+                                            filename = d['_id']
+                                            extra_features = (
+                                                extra_features_by_file.get(
+                                                    filename, []
+                                                )
+                                            )
+                                            if extra_features:
+                                                d = {
+                                                    **d,
+                                                    **{
+                                                        feature: 1 for feature
+                                                        in extra_features
+                                                    },
+                                                }
                                             a = json.dumps(d, ensure_ascii=False
                                                     ).encode('utf-8')
                                             s.write(a)
@@ -921,7 +951,7 @@ class Client(vuespa.Client):
     async def _cmd_plugin_template_replace(self, cmd, api_url, extra_template_vars,
             extra_api_info):
         if not api_url.endswith('/'):
-            api_url = api_url+ '/'
+            api_url = api_url + '/'
 
         template_vals = {
                 '<apiInfo>': lambda: json.dumps(_get_api_info(extra_api_info)),
@@ -999,23 +1029,6 @@ class Client(vuespa.Client):
                 else:
                     os.unlink(f)
 
-
-    async def _statsbyfile_cursor(self, options, match_id=None):
-        """Async generator which yields from `statsbyfile` according to the
-        working subsetting options in `options`.
-
-        For efficiency, yields batches rather than individual documents! This
-        cuts overhead by as much as 50% due to the way async works in python.
-
-        Args:
-            options:
-                analysis_set_id: Analysis set to use for returning results
-                file_ids?: Optional list of file IDs to restrict results.
-            match_id: Document id to return.
-        """
-        async for v in fetch_statsbyfile(options, match_id):
-            yield v
-
     async def api_loading_get(self, options):
         """Returns an object with {loading: boolean, message: string}.
 
@@ -1072,7 +1085,7 @@ class Client(vuespa.Client):
         elif collection == 'statsbyfile':
             # This is now a virtual collection; select data from relevant places
             if other_options and other_options.get('as_only'):
-                cursor = self._statsbyfile_cursor(as_options, match_id=pdf)
+                cursor = fetch_statsbyfile(as_options, match_id=pdf)
                 cursor_batched = True
                 as_options = None
             else:

--- a/faw/pdf-observatory/ui/package.json
+++ b/faw/pdf-observatory/ui/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
   },
   "dependencies": {
     "d3": "^4.x",

--- a/faw/pdf-observatory/ui/src/components/FileFilterDetail.vue
+++ b/faw/pdf-observatory/ui/src/components/FileFilterDetail.vue
@@ -86,7 +86,7 @@ export default Vue.extend({
     decisionSelected: Object as PropType<PdfDecision>,
     decisionSelectedDsl: Object as PropType<PdfDecision>,
     decisionReference: Object as PropType<PdfDecision>,
-    extraFeaturesByFile: Map as PropType<Map<string, string[]>>,
+    extraFeaturesByFile: Object as PropType<{[filename:string]:string[]}>,
   },
   data() {
     return {
@@ -129,7 +129,7 @@ export default Vue.extend({
       if (tf) {
         const data = await this.$vuespa.call('load_db', tf, 'statsbyfile',
             this.asOptions, {as_only: this.fileStatsAsOnly});
-        const extraFeatures = this.extraFeaturesByFile.get(tf);
+        const extraFeatures = this.extraFeaturesByFile[tf];
         for (const extraFeature of (extraFeatures !== undefined ? extraFeatures : [])) {
           data[0][extraFeature] = 1;
         }

--- a/faw/pdf-observatory/ui/src/components/FileFilterDetail.vue
+++ b/faw/pdf-observatory/ui/src/components/FileFilterDetail.vue
@@ -38,7 +38,7 @@
                     v-btn(v-clipboard="() => regexEscape(k[0])") (Copy regex to clipboard)
                     v-btn(v-clipboard="() => '^' + regexEscape(k[0]) + '$'") (with ^$)
 
-    .decision-reasons Full listing of reasons (#[checkmark(:status="'valid'")] for filters: passed 'all' or rejected by 'any'; click to copy to clipboard):
+    .decision-reasons Full listing of reasons (#[checkmark(:status="'valid'")] indicates a match for filters; click to copy to clipboard):
       div(style="display: flex; flex-direction: row; align-items: start; margin-bottom: -1.5em")
         span (
         v-checkbox(

--- a/faw/pdf-observatory/ui/src/components/FileFilterDetail.vue
+++ b/faw/pdf-observatory/ui/src/components/FileFilterDetail.vue
@@ -69,7 +69,7 @@
 </style>
 
 <script lang="ts">
-import Vue from 'vue';
+import Vue, {PropType} from 'vue';
 
 import CheckmarkComponent from '@/components/CheckmarkComponent.vue';
 import {PdfDecision, sortByReject} from '@/common/common';
@@ -81,11 +81,12 @@ export default Vue.extend({
     checkmark: CheckmarkComponent,
   },
   props: {
-    asOptions: Object as () => any,  // Options for analysis set
-    decisionDefinition: Object as () => DslResult | null,
-    decisionSelected: Object as () => PdfDecision,
-    decisionSelectedDsl: Object as () => PdfDecision,
-    decisionReference: Object as () => PdfDecision,
+    asOptions: Object as PropType<any>,  // Options for analysis set
+    decisionDefinition: Object as PropType<DslResult | null>,
+    decisionSelected: Object as PropType<PdfDecision>,
+    decisionSelectedDsl: Object as PropType<PdfDecision>,
+    decisionReference: Object as PropType<PdfDecision>,
+    extraFeaturesByFile: Map as PropType<Map<string, string[]>>,
   },
   data() {
     return {
@@ -128,6 +129,10 @@ export default Vue.extend({
       if (tf) {
         const data = await this.$vuespa.call('load_db', tf, 'statsbyfile',
             this.asOptions, {as_only: this.fileStatsAsOnly});
+        const extraFeatures = this.extraFeaturesByFile.get(tf);
+        for (const extraFeature of (extraFeatures !== undefined ? extraFeatures : [])) {
+          data[0][extraFeature] = 1;
+        }
         // Prevent duplicates by re-setting the array whenever we get data
         this.fileStats.clear();
         this.fileStats.set('other', []);

--- a/faw/pdf-observatory/ui/src/views/HomeView.vue
+++ b/faw/pdf-observatory/ui/src/views/HomeView.vue
@@ -46,9 +46,10 @@ mixin stale-decisions-alert
     dense
     :type="filtersError ? 'error' : (filtersModified || pdfGroupsDirty || pdfGroupsLoading) ? 'warning' : 'success'"
   )
-    span(v-if="filtersError") Filters could not be run; fix and 'Reprocess' to update decisions. 
+    span(v-if="filtersError")
+      | Filters could not be run; fix and 'Reprocess' to update decisions.
       br
-      span {{filtersError}}
+      | {{filtersError}}
     span(v-else-if="filtersModified") Filters have been modified; 'Reprocess' to update decisions
     span(v-else-if="pdfGroupsDirty") Data is stale; 'Reprocess' to download fresh data
     span(v-else-if="pdfGroupsLoading") Data is loading...
@@ -124,7 +125,9 @@ mixin confusion-matrix
               template(v-slot:activator="{on}")
                 div(v-on="on")
                   v-btn.download(@click="downloadFeatures") Download features
-              span Downloads all features loaded in UI as a matrix of features x files; blank values indicate that a file does NOT have that feature.
+              span
+                | Downloads all features loaded in UI as a matrix of features x files;
+                | blank values indicate that a file does NOT have that feature.
           +stale-decisions-alert
 
           v-sheet(:elevation="3" style="margin-block: 1em; padding: 1em")
@@ -1478,6 +1481,7 @@ export default Vue.extend({
         this.filtersError = null;
       } catch (error: unknown) {
         this.filtersError = error as Error;
+        console.error(error);
       }
     },
     reprocessPost() {

--- a/faw/pdf-observatory/ui/src/views/HomeView.vue
+++ b/faw/pdf-observatory/ui/src/views/HomeView.vue
@@ -653,7 +653,7 @@ export default Vue.extend({
       decisionSearchCustom: '',
       decisionSearchInsensitive: true,
       decisionSelectedDsl: {} as PdfDecision,
-      extraFeaturesByFile: new Map<string, string[]>(),
+      extraFeaturesByFile: {} as {[filename:string]: string[]},
       error: false as any,
       expansionPanels: [0, 1, 2],
       // failReasons points from a filter name to an Array of [relevant message, [files failing non-uniquely, files uniquely failing]
@@ -1286,7 +1286,7 @@ export default Vue.extend({
             jsonArgs,
             refDecs,
             this._pdfGroupsSubsetOptions(true),
-            Object.fromEntries(this.extraFeaturesByFile),
+            this.extraFeaturesByFile,
           );
           if (this.pluginDecIframeLoading !== loadKey) return;
           this.pluginDecIframeSrc = r.html;
@@ -1476,7 +1476,9 @@ export default Vue.extend({
         const newPdfs = reprocessResult.decisions;
         this.pdfs = Object.freeze(newPdfs);
         this.pdfsDslLast = Object.freeze(newPdfs);
-        this.extraFeaturesByFile = reprocessResult.extraFeaturesByFile;
+        this.extraFeaturesByFile = Object.freeze(
+          Object.fromEntries(reprocessResult.extraFeaturesByFile)
+        );
         this.reprocessPost();
         this.filtersError = null;
       } catch (error: unknown) {

--- a/faw/scripts/faw_ci_cli.py
+++ b/faw/scripts/faw_ci_cli.py
@@ -114,6 +114,7 @@ def _handle_get_decisions(args):
         '--data-urlencode', f'dsl@{str(dsl_path)}',
         f'http://{args.host}:{args.port}/decisions'
     ])
+    output = output.decode()
 
     if args.format:
         obj = json.loads(output)

--- a/nitf/dsl.txt
+++ b/nitf/dsl.txt
@@ -1,4 +1,9 @@
 # Any line beginning with a hash is a comment.
+
+# features:
+#   # Extra features derived from parser output, added to the set of features available to filters and decision plugins.
+#   # Defined as lists of regular expressions just like filters (see below).
+
 filters:
   # Filters are defined as groups of regular expressions.
 

--- a/pdf/dsl.txt
+++ b/pdf/dsl.txt
@@ -1,5 +1,13 @@
 # Any line beginning with a hash is a comment.
 
+# features:
+#   # Extra features derived from parser output, added to the set of features available to filters and decision plugins.
+#   # Defined as lists of regular expressions just like filters (see below).
+#
+#   differential:
+#     ^schizo-test-schizo-test_Max RMSE
+#       sum > 0.4
+
 filters:
   # Filters are defined as groups of regular expressions.
 


### PR DESCRIPTION
Adds a new top-level section `features` to the DSL in which users can specify additional features derived from plugin output. These can then be used in DSL filters, custom regex search, per-file analysis, and decision plugins.

Implementation note: To support multiple clients, the extra features are stored client-side only. They are only passed to the server when invoking decision plugins, and are not kept in the database.

Syntax example:
```yaml
# Features (optional section)
#   Passed to decision plugins along with other features
#   Can be used in filter definitions in the DSL
#   Definition uses the same schema as filters
#     `/i` is supported, as for filters
features:
  differential:
    ^schizo-test-schizo-test_Max RMSE
      sum > 0.4

filters:
  Differential:
    # Derived feature text is matched with a regex just like parser output
    ^differential$
outputs:
  status:
    "valid" is !Differential
    "rejected" else
```

Edit: Also removed the `all` option from filters.