### PR TITLE
Add "/and" option for DSL rules, fix PDF python dependency issues

### DIFF
--- a/faw/pdf-observatory/ui/src/views/HomeView.vue
+++ b/faw/pdf-observatory/ui/src/views/HomeView.vue
@@ -158,8 +158,8 @@ mixin confusion-matrix
                 v-expansion-panel-content
                   .decision-reasons
                     v-radio-group(v-model="failReasonsSort" row :label="(failReasons.get(decisionAspectSelected) || []).length + ' error messages, sorted by'")
-                      v-radio(value="total" label="number of files rejected")
-                      v-radio(value="unique" label="uniquely rejected")
+                      v-radio(value="total" label="number of files affected")
+                      v-radio(value="unique" label="uniquely affected")
                     v-virtual-scroll(
                       :bench="10"
                       :items="failReasons.get(decisionAspectSelected) || []"
@@ -1116,6 +1116,7 @@ export default Vue.extend({
             dd.filters.push({
                 name: filtName,
                 caseInsensitive: false,
+                conjunction: false,
                 patterns: Array.from(messages).map(x => ({pat: x, check: null})),
             });
             vv[1] = {type: 'id', id1: filtName};
@@ -1132,12 +1133,30 @@ export default Vue.extend({
         text.push(t);
         text.push('\n');
       };
+      add('features:');
+      indent += 1;
+      for (const k of dd.extraFeatures) {
+        let header = k.featureText.slice();
+        if (k.caseInsensitive)
+          header += '/i';
+        if (k.conjunction)
+          header += '/and';
+        header += ':';
+        add(header);
+        indent += 1;
+        for (const kk of k.patterns) {
+          add(kk.pat);
+        }
+        indent -= 1;
+      }
       add('filters:');
       indent += 1;
       for (const k of dd.filters) {
         let header = k.name.slice();
         if (k.caseInsensitive)
           header += '/i';
+        if (k.conjunction)
+          header += '/and';
         header += ':';
         add(header);
         indent += 1;
@@ -1426,6 +1445,7 @@ export default Vue.extend({
         dd.filters.push({
           name: 'faw-custom',
           caseInsensitive: this.decisionSearchInsensitive,
+          conjunction: false,
           patterns: [{pat: this.decisionSearchCustom, check: null}],
         });
       }
@@ -1435,6 +1455,7 @@ export default Vue.extend({
       dd.filters.push({
         name: 'faw-errors',
         caseInsensitive: true,
+        conjunction: false,
         patterns: [
           {pat: '_<<workbench: Exit code missing', check: null},
           {pat: '_<<workbench: Exit status: RuntimeError', check: null},

--- a/pdf/differential_test/config.json5
+++ b/pdf/differential_test/config.json5
@@ -10,7 +10,7 @@
     'differential-test': {
       exec: ['./main.py', '<artifactInParserDirs pageImages100dpi>', '<tempDir>'],
       timeout: 120,
-      version: 'differential-test72',
+      version: 'differential-test73',
       parse: {
         type: 'regex-counter',
         version: '2',

--- a/pdf/differential_test/config.json5
+++ b/pdf/differential_test/config.json5
@@ -13,19 +13,19 @@
       version: 'differential-test72',
       parse: {
         type: 'regex-counter',
-        version: '1',
+        version: '2',
         stdstar: {
-          '^(Max RMSE, .*?): (.*?)': {
+          '^(Max RMSE, .*?): (.*?)$': {
             nameGroup: 1,
             countGroup: 2,
             countAsNumber: true,
           },
-          '^(Max diff, .*?): (.*?)': {
+          '^(Max diff, .*?): (.*?)$': {
             nameGroup: 1,
             countGroup: 2,
             countAsNumber: true,
           },
-          '^Differential: .*': {
+          '^Differential: .*$': {
             nameReplace: {
               '[0-9]': '',
             },

--- a/pdf/differential_test/main.py
+++ b/pdf/differential_test/main.py
@@ -99,6 +99,9 @@ def main():
                 print(f'Discarded transparency from {t} page {pageno}')
                 # alpha to white; equivalent to `img = img[:, :, :3]` for opaque images
                 img = img[:, :, :3] * np.atleast_3d(img[:, :, 3]) / 255
+            if img.shape[2] == 1:
+                # Image was grayscale; convert to RGB for visual comparison
+                img = np.broadcast_to(img, (*img.shape[:2], 3))
             page_images[-1] = img  # replace placeholder (None)
 
             if html_out and ti > 0:
@@ -119,8 +122,8 @@ def main():
                     print(f'<td>')
                     if diff is not None:
                         buf = io.BytesIO()
-                        imgdat = imageio.imwrite(buf, 255 - diff,
-                                'png')
+                        diff_rgb = np.broadcast_to(255 - diff * 255, (*diff.shape[:2], 3)).astype(np.uint8)
+                        imgdat = imageio.v2.imwrite(buf, diff_rgb, 'png')
                         buf.seek(0)
                         b64 = base64.b64encode(buf.read()).decode('latin1')
                         print(f'<img src="data:image/png;base64,{b64}" {img_attrs} />')

--- a/pdf/differential_test/requirements.txt
+++ b/pdf/differential_test/requirements.txt
@@ -1,4 +1,4 @@
-imageio
+imageio ~=2.29.0
 # If opencv-python gives errors about skbuild, run `pip install --upgrade pip`
 # https://stackoverflow.com/questions/63448467/installing-opencv-fails-because-it-cannot-find-skbuild
 opencv-python

--- a/pdf/differential_text_test/config.json5
+++ b/pdf/differential_text_test/config.json5
@@ -13,9 +13,9 @@
       version: 'differential-6.8',
       parse: {
         type: 'regex-counter',
-        version: '1',
+        version: '2',
         stdstar: {
-          '^Min (.*? to .*?): (.*?)': {
+          '^Min (.*? to .*?): (.*?)$': {
             nameGroup: 1,
             countGroup: 2,
             countAsNumber: true,

--- a/pdf/differential_text_test/requirements.txt
+++ b/pdf/differential_text_test/requirements.txt
@@ -1,2 +1,4 @@
-spacy
-
+spacy ~=3.5.3
+pydantic ~=1.10.9
+# Pin typing_extensions to 4.6 for pydantic
+typing_extensions ==4.6.3

--- a/pdf/dsl.txt
+++ b/pdf/dsl.txt
@@ -10,6 +10,11 @@
 
 filters:
   # Filters are defined as groups of regular expressions.
+  # By default, a file passes a filter if any of its features match
+  # any of the expressions listed.
+  # This behavior can be changed to require a match for all expressions
+  # by adding `/and` after the filter name.
+  # Adding `/i` after the filter name makes the filter case-insensitive.
 
   # Global notes --  permitting "FONT Arial[-,]" and "arialbd.ttf" makes a difference. but technically not base fonts.
   # A more rigorous font line: #^parser\-xpdf\-pdffonts_FONT.*EMB no.*(?<!/([Cc]our\S*|[Hh]elve\S*|[Tt]imes\S*)\.ttf)$

--- a/pdf/parser-hammerpdf/config.json5
+++ b/pdf/parser-hammerpdf/config.json5
@@ -1,4 +1,5 @@
 {
+    disabled: true,  // Download links are broken
     parsers: {
         'validate': {
             exec: ['/parsec/pdf/pdf', '<inputFile>'],

--- a/pdf/plugin-polytracker/config.json5
+++ b/pdf/plugin-polytracker/config.json5
@@ -28,6 +28,9 @@
       final: {
         commands: [
           'RUN pip3 install "polytracker == 3.1.0"',
+          // polytracker pins `typing_extensions>=3.7.4.2`, which is a bad version,
+          // causing issues in other plugins. 4.6.3 is the latest
+          'RUN pip3 install "typing_extensions == 4.6.3"',
         ],
       }
     },


### PR DESCRIPTION
This update adds a new mode for filters (and added features) in the DSL, written like so:

```
features:
  conjunction-feature/and:
    ^regex1
    ^regex2

filters:
  ConjunctionFilter/and:
    ^regex1
    ^regex2
```

The feature/filter is satisfied only when each regex is matched by at least one message. This is documented in the default PDF DSL text in a comment.

Also, a failure to build a coherent python environment for the PDF distribution is fixed. There were two issues here:

* `pydantic` (imported by some upstream dependencies of the text diff plugin) was updated and no longer works with the (bad) version of typing_extensions pinned by polytracker
* `imageio`'s (dep of the visual diff plugin) default behavior changed in an update

This changeset pins relevant deps and fixes our use of imageio.

Also, grayscale images of PDFs are now properly converted to RGB before doing the visual comparison (we had been getting a dimension mismatch result in such cases). This affects the output of this parser, so it will rerun for all files in live deployments.