### PR TITLE
Check disk space before parsing, display a parse error on the frontend

### DIFF
--- a/faw/pdf-observatory/main.py
+++ b/faw/pdf-observatory/main.py
@@ -1053,12 +1053,20 @@ class Client(vuespa.Client):
 
         # Hack for pipeline debugging
         idle_text = '' if not pdfs_idle else f' ({pdfs_idle} from idle)'
+        error_detail = ''
+        if pdfs_err > 0:
+            # Just show the user one random exception (faster than reading all failures)
+            error_detail = (
+                await app_mongodb_conn[faw_analysis_set_parse.COL_NAME]
+                .find_one({'error_until': {'$exists': True}}, {'error_exception'})
+            )['error_exception']
         return {
                 'config_mtime': app_config_loaded,
                 'files_parsing': pdfs_not_done,
                 'files_max': pdfs_max,
                 'files_err': pdfs_err,
                 'message': f'{pdfs_not_done} / {pdfs_max} files parsing{idle_text}; {pdfs_err} errors',
+                'detail': error_detail,
         }
 
 

--- a/faw/pdf-observatory/ui/src/components/AnalysisSetConfig.vue
+++ b/faw/pdf-observatory/ui/src/components/AnalysisSetConfig.vue
@@ -106,7 +106,16 @@
       div
         span
           v-icon mdi-help-rhombus
-        span(style="font-size:0.85em") Pipelines attached to analysis sets are a two-stage process: 1) The pipeline is initiated. All files *currently* matching the analysis set definition, ignoring max documents, will be available to the pipeline. Thus, best to wait until all non-pipeline parsers have finished. 2) When the pipeline finishes all of its tasks, and if the pipeline specifies any parsers, all analysis sets which have specified that they will use this pipeline's parsers will have their files processed with the parsers learned from this analysis set.
+        span(style="font-size:0.85em")
+          | Pipelines attached to analysis sets are a two-stage process:
+          | 1) The pipeline is initiated. All files *currently* matching
+          | the analysis set definition, ignoring max documents, will be
+          | available to the pipeline. Thus, best to wait until all
+          | non-pipeline parsers have finished. 2) When the pipeline
+          | finishes all of its tasks, and if the pipeline specifies any
+          | parsers, all analysis sets which have specified that they will
+          | use this pipeline's parsers will have their files processed
+          | with the parsers learned from this analysis set.
       v-expansion-panels
         AnalysisSetPipelineInfo(v-for="[k, v] of Object.entries(pipeCfg)"
             v-if="!v.disabled"

--- a/faw/pdf-observatory/ui/src/views/HomeView.vue
+++ b/faw/pdf-observatory/ui/src/views/HomeView.vue
@@ -76,14 +76,16 @@ mixin confusion-matrix
     `
   )
     v-card(color="grey darken-1" dark)
-      v-card-text(style="padding-top: 0.5em;") {{loadingStatus.message}}
-        v-progress-linear(
-          :height="8"
-          :indeterminate="loadingStatus.files_parsing !== 0"
-          rounded
-          :color="loadingStatus.files_err === 0 ? 'white' : 'red'"
-          :value="loadingStatus.files_parsing ? 100 : 0"
-        )
+      v-card-text(style="padding-block: 0.5em;") {{loadingStatus.message}}
+      v-progress-linear(
+        :height="8"
+        :indeterminate="loadingStatus.files_parsing !== 0"
+        rounded
+        :color="loadingStatus.files_err === 0 ? 'white' : 'red'"
+        :value="loadingStatus.files_parsing ? 100 : 0"
+      )
+      v-card-text(style="padding-block: 0.5em;" v-if="loadingStatus.files_err")
+        details {{loadingStatus.detail}}
   .error(v-if="error" style="font-size: 4em; white-space: pre-wrap") ERROR - SEE CONSOLE
 
   .page-container


### PR DESCRIPTION
Addresses #98

Changes:
- If there is less than a hardcoded minimum amount of space left on disk (both `/` and `/data/db` are checked, since they can be on different partitions), parsing is not attempted and the file is marked as an error so it can be rerun.
- If there are any parse errors, one message is displayed on the frontend in a collapsible details element.
  - This applies to a few other types of error as well, such as dask issues, and parser failures when marked as `mustSucceed`

Screenshots of the error details (the error progress bar flashes, so it's not visible in two of these images):
- ![Screenshot 2023-08-22 at 11 52 19](https://github.com/GaloisInc/FAW/assets/15271537/159443f3-ab10-4071-8ae4-8cad3c3faf33)
- Tested by modifying the disk space minimum; in real usage this number will be in the kilobytes rather than the gigabytes, so displaying it in bytes is more reasonable:
  ![Screenshot 2023-08-22 at 11 57 39](https://github.com/GaloisInc/FAW/assets/15271537/101c9bb5-2dee-4295-8cca-7c06b3177d0b)
- ![Screenshot 2023-08-22 at 11 52 11](https://github.com/GaloisInc/FAW/assets/15271537/13275916-a44a-4860-8374-aa93e81ad958)
