### PR TITLE
Fix/text rendering pdf parsers issue 103

### DIFF
--- a/pdf/parser-mupdf/config.json5
+++ b/pdf/parser-mupdf/config.json5
@@ -193,8 +193,8 @@
         },
 
         'mutool-draw-txt': {
-            exec: ['bash', '-c', 'mutool draw -F txt -o - $0 | tee $1', '<inputFile>', '<artifactOutFile pageText all-pages.txt>'],
-            version: 'mupdf-1.16',
+            exec: ['bash', '-c', 'mutool draw -F txt -o - "$0" | tee "$1"', '<inputFile>', '<artifactOutFile pageText all-pages.txt>'],
+            version: 'mupdf-1.16-1',
             parse: {
                 type: 'regex-counter',
                 version: '1',

--- a/pdf/parser-pdfminer/config.json5
+++ b/pdf/parser-pdfminer/config.json5
@@ -28,7 +28,7 @@
         'pdf2text': {
             disabled: false,
             exec: ['bash', '-c', 'python3 /usr/local/bin/pdf2txt.py "$0" | tee "$1"', '<inputFile>', '<artifactOutFile pageText all-pages.txt>'],
-            version: '10.0.1-six',
+            version: '10.0.1-six-1',
             parse: {
                 type: 'regex-counter',
                 version: '1',

--- a/pdf/parser-pdfminer/config.json5
+++ b/pdf/parser-pdfminer/config.json5
@@ -27,7 +27,7 @@
         // Dumps pdf to text
         'pdf2text': {
             disabled: false,
-            exec: ['bash', '-c', 'python3 /usr/local/bin/pdf2txt.py $0 | tee $1', '<inputFile>', '<artifactOutFile pageText all-pages.txt>'],
+            exec: ['bash', '-c', 'python3 /usr/local/bin/pdf2txt.py "$0" | tee "$1"', '<inputFile>', '<artifactOutFile pageText all-pages.txt>'],
             version: '10.0.1-six',
             parse: {
                 type: 'regex-counter',

--- a/pdf/parser-poppler/config.json5
+++ b/pdf/parser-poppler/config.json5
@@ -3,7 +3,7 @@
 
         pdftotext: {
           exec: ['bash', '-c', 'pdftotext -enc UTF-8 "$0" - | tee "$1"', '<inputFile>', '<artifactOutFile pageText all-pages.txt>'],
-          version: 'poppler-0.86.1',
+          version: 'poppler-0.86.1-1',
           parse: {
             type: 'regex-counter',
             version: '1',

--- a/pdf/parser-poppler/config.json5
+++ b/pdf/parser-poppler/config.json5
@@ -2,7 +2,7 @@
     parsers: {
 
         pdftotext: {
-          exec: ['bash', '-c', 'pdftotext -enc UTF-8 $0 - | tee $1', '<inputFile>', '<artifactOutFile pageText all-pages.txt>'],
+          exec: ['bash', '-c', 'pdftotext -enc UTF-8 "$0" - | tee "$1"', '<inputFile>', '<artifactOutFile pageText all-pages.txt>'],
           version: 'poppler-0.86.1',
           parse: {
             type: 'regex-counter',

--- a/pdf/parser-qpdf/config.json5
+++ b/pdf/parser-qpdf/config.json5
@@ -3,7 +3,7 @@
         'qpdf-json' : {
             // Stdout w/ json is prohibitively large, do not store in db
             exec: ['bash', '-c', 'qpdf --json "$0" > /dev/null', '<inputFile>'],
-            version: '10.0.1',
+            version: '10.0.1-1',
             parse: {
                 type: 'regex-counter',
                 version: '1',

--- a/pdf/parser-qpdf/config.json5
+++ b/pdf/parser-qpdf/config.json5
@@ -2,7 +2,7 @@
     parsers: {
         'qpdf-json' : {
             // Stdout w/ json is prohibitively large, do not store in db
-            exec: ['bash', '-c', 'qpdf --json $0 > /dev/null', '<inputFile>'],
+            exec: ['bash', '-c', 'qpdf --json "$0" > /dev/null', '<inputFile>'],
             version: '10.0.1',
             parse: {
                 type: 'regex-counter',

--- a/pdf/parser-xpdf/config.json5
+++ b/pdf/parser-xpdf/config.json5
@@ -3,7 +3,7 @@
 
         "pdftotext": {
           disabled: false,
-          exec: ['bash', '-c', '/opt/xpdf/bin64/pdftotext -enc UTF-8 $0 - | tee $1', '<inputFile>', '<artifactOutFile pageText all-pages.txt>'],
+          exec: ['bash', '-c', '/opt/xpdf/bin64/pdftotext -enc UTF-8 "$0" - | tee "$1"', '<inputFile>', '<artifactOutFile pageText all-pages.txt>'],
           version: 'xpdf-4.0.2',
           parse: {
             type: 'regex-counter',

--- a/pdf/parser-xpdf/config.json5
+++ b/pdf/parser-xpdf/config.json5
@@ -4,7 +4,7 @@
         "pdftotext": {
           disabled: false,
           exec: ['bash', '-c', '/opt/xpdf/bin64/pdftotext -enc UTF-8 "$0" - | tee "$1"', '<inputFile>', '<artifactOutFile pageText all-pages.txt>'],
-          version: 'xpdf-4.0.2',
+          version: 'xpdf-4.0.2-1',
           parse: {
             type: 'regex-counter',
             version: '1',

--- a/pdf/plugin-pdf-valgrind/config.json5
+++ b/pdf/plugin-pdf-valgrind/config.json5
@@ -4,8 +4,8 @@
       version: 'poppler-20.09.0-4',
       exec: ['bash', '-c',
         ' \
-        valgrind --tool=callgrind --callgrind-out-file=$1 pdfinfo -struct $0 > /dev/null 2>&1 \
-        ; callgrind_annotate --tree=both --threshold=100 $1 \
+        valgrind --tool=callgrind --callgrind-out-file=$1 pdfinfo -struct "$0" > /dev/null 2>&1 \
+        ; callgrind_annotate --tree=both --threshold=100 "$1" \
           | grep -P " *\\d+(,\\d+)* +\\* " | sed -n "s/.*  \\*  \\(.*\\)/\\1/p" \
         ',
         '<inputFile>',

--- a/pdf/plugin-pdf-valgrind/config.json5
+++ b/pdf/plugin-pdf-valgrind/config.json5
@@ -1,7 +1,7 @@
 {
   parsers: {
     "pdfinfo-struct-valgrind": {
-      version: 'poppler-20.09.0-4',
+      version: 'poppler-20.09.0-5',
       exec: ['bash', '-c',
         ' \
         valgrind --tool=callgrind --callgrind-out-file=$1 pdfinfo -struct "$0" > /dev/null 2>&1 \


### PR DESCRIPTION
Fairly straightforward bug fix. Quoting the bash arguments is safer.

Fixes #103 