### PR TITLE
Update FAW CI container and PDF distribution to ubuntu 22

### DIFF
--- a/faw/ci/ci-container-dockerfile
+++ b/faw/ci/ci-container-dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:20.04 AS base
+FROM ubuntu:22.04 AS base
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install basic tools including Python
 # Note: This will install python3.8, the default python version on ubuntu 20.04
 # We'd need to bump ubuntu or add channels to get newer python
-RUN apt-get update && apt-get install -y curl python3 python3-pip wget
+RUN apt-get update && apt-get install -y curl python3.10 python3-pip wget
 
 # Install docker in the container, mainly for the cli
 # TODO: Is there a better way to get the cli in there?

--- a/faw/ci/ci_container_service.py
+++ b/faw/ci/ci_container_service.py
@@ -721,7 +721,7 @@ def _create_dockerfile_contents(development, config, config_data, build_dir, bui
         # in the same image. So, clone the latest mongodb from the official
         # image.
         'obs__mongo': {
-            'from': 'mongo:6.0.10-jammy',
+            'from': 'mongo:4.4.12',
             'copy_output': {
                 '/var/log/mongodb': True,
                 #'/var/lib/dpkg/info': True,
@@ -737,9 +737,7 @@ def _create_dockerfile_contents(development, config, config_data, build_dir, bui
                 '/etc/apt/sources.list.d/mongodb-org.list': True,
                 #'/etc/apt/trusted.gpg.d/mongodb.gpg': True,
                 '/etc/mongod.conf.orig': True,
-
                 # For newer versions of Ubuntu, must copy libcrypt* and libssl*
-                # Trying a funny formulation that avoids explicit x86 dependency
                 '/usr/lib/*/libcrypto.so*': '/usr/lib/',
                 '/usr/lib/*/libssl.so*': '/usr/lib/',
             },
@@ -847,7 +845,7 @@ def _create_dockerfile_contents(development, config, config_data, build_dir, bui
             # Ensure that e.g. curl, python3, python3-pip, and wget all get installed
             stage_commands = [
                     'ENV DEBIAN_FRONTEND=noninteractive',
-                    'RUN apt-get update && apt-get install -y curl python3 python3-pip wget',
+                    'RUN apt-get update && apt-get install -y curl python3.10 python3-pip wget',
                     ] + stage_commands
         dockerfile.extend(stage_commands)
 

--- a/faw/ci/ci_container_service.py
+++ b/faw/ci/ci_container_service.py
@@ -753,8 +753,7 @@ def _create_dockerfile_contents(development, config, config_data, build_dir, bui
             # Install npm globally, so it's available for debug mode
             RUN wget -qO - https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | apt-key add -
             RUN echo "deb https://deb.nodesource.com/node_16.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
-            RUN apt-get update
-            RUN apt-get -y install --no-install-recommends nodejs
+            RUN apt-get update && apt-get -y install --no-install-recommends nodejs
             # Install watchgod, which allows for live-reloading analysis sets
             # on file changes.
             RUN pip3 install watchgod
@@ -766,8 +765,7 @@ def _create_dockerfile_contents(development, config, config_data, build_dir, bui
             # Install npm locally, only for the build.
             RUN wget -qO - https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | apt-key add -
             RUN echo "deb https://deb.nodesource.com/node_16.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
-            RUN apt-get update
-            RUN apt-get -y install --no-install-recommends nodejs
+            RUN apt-get update && apt-get -y install --no-install-recommends nodejs
             COPY {build_faw_dir}/faw/pdf-observatory/common /home/pdf-observatory/common
             COPY {build_faw_dir}/faw/pdf-observatory/ui /home/pdf-observatory/ui
             RUN cd /home/pdf-observatory/ui \

--- a/faw/ci/ci_container_service.py
+++ b/faw/ci/ci_container_service.py
@@ -721,7 +721,7 @@ def _create_dockerfile_contents(development, config, config_data, build_dir, bui
         # in the same image. So, clone the latest mongodb from the official
         # image.
         'obs__mongo': {
-            'from': 'mongo:4.4.12',
+            'from': 'mongo:6.0.10-jammy',
             'copy_output': {
                 '/var/log/mongodb': True,
                 #'/var/lib/dpkg/info': True,

--- a/faw/ci/ci_container_service.py
+++ b/faw/ci/ci_container_service.py
@@ -751,7 +751,10 @@ def _create_dockerfile_contents(development, config, config_data, build_dir, bui
         # Development extensions... add not-compiled code directories.
         dockerfile_final.append(r'''
             # Install npm globally, so it's available for debug mode
-            RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
+            RUN wget -qO - https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | apt-key add -
+            RUN echo "deb https://deb.nodesource.com/node_16.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
+            RUN apt-get update
+            RUN apt-get -y install --no-install-recommends nodejs
             # Install watchgod, which allows for live-reloading analysis sets
             # on file changes.
             RUN pip3 install watchgod
@@ -761,7 +764,10 @@ def _create_dockerfile_contents(development, config, config_data, build_dir, bui
         dockerfile_middle.append(rf'''
             FROM base AS ui-builder
             # Install npm locally, only for the build.
-            RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
+            RUN wget -qO - https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | apt-key add -
+            RUN echo "deb https://deb.nodesource.com/node_16.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
+            RUN apt-get update
+            RUN apt-get -y install --no-install-recommends nodejs
             COPY {build_faw_dir}/faw/pdf-observatory/common /home/pdf-observatory/common
             COPY {build_faw_dir}/faw/pdf-observatory/ui /home/pdf-observatory/ui
             RUN cd /home/pdf-observatory/ui \

--- a/faw/pdf-observatory/main.py
+++ b/faw/pdf-observatory/main.py
@@ -111,7 +111,7 @@ def main(pdf_dir, mongodb, host, port, hostname, in_docker, production, config,
     # https://docs.mongodb.com/manual/reference/limits/
     async def admin_cfg():
         await app_mongodb_conn.client.admin.command({
-                'setFeatureCompatibilityVersion': '4.4'})
+                'setFeatureCompatibilityVersion': '6.0'})
     loop.run_until_complete(admin_cfg())
 
     app_config_refresh = loop.create_task(_config_check_loop())

--- a/faw/pdf-observatory/main.py
+++ b/faw/pdf-observatory/main.py
@@ -111,7 +111,7 @@ def main(pdf_dir, mongodb, host, port, hostname, in_docker, production, config,
     # https://docs.mongodb.com/manual/reference/limits/
     async def admin_cfg():
         await app_mongodb_conn.client.admin.command({
-                'setFeatureCompatibilityVersion': '6.0'})
+                'setFeatureCompatibilityVersion': '4.4'})
     loop.run_until_complete(admin_cfg())
 
     app_config_refresh = loop.create_task(_config_check_loop())

--- a/icc/config.json5
+++ b/icc/config.json5
@@ -175,7 +175,7 @@ outputs:  \n\
             // to specify their own 'from' keys.
 
             base: {
-                'from': 'ubuntu:21.04',
+                'from': 'ubuntu:22.04',
                 commands: [
                     // Base packages
                     'RUN apt-get update && apt-get install -y \

--- a/nitf/config.json5
+++ b/nitf/config.json5
@@ -62,7 +62,7 @@
     build: {
         stages: {
             base: {
-                'from': 'ubuntu:20.04',
+                'from': 'ubuntu:22.04',
                 commands: [
                     'ENV DEBIAN_FRONTEND=noninteractive',
                     'SHELL ["/bin/bash", "-c"]',

--- a/pdf/config.json5
+++ b/pdf/config.json5
@@ -497,7 +497,7 @@ with open(sys.argv[1], 'w') as html: \n\
             // copying, e.g., requirements.txt
 
             base: {
-                'from': 'ubuntu:20.04',
+                from: 'ubuntu:22.04',
                 commands: [
                     'ENV DEBIAN_FRONTEND=noninteractive',
 
@@ -516,7 +516,7 @@ with open(sys.argv[1], 'w') as html: \n\
                         gettext \
                         autopoint \
                         autoconf \
-                        python3-dev \
+                        python3.10-dev \
                         libssl-dev \
                         cmake \
                         libfreetype6-dev \
@@ -531,7 +531,7 @@ with open(sys.argv[1], 'w') as html: \n\
                     // uses a nuclear option to select all available ubuntu fonts packages.
                     'RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections',
                     "RUN apt-get update \
-                      && apt-get install -y ttf-mscorefonts-installer ttf-dejavu-core \
+                      && apt-get install -y ttf-mscorefonts-installer fonts-dejavu \
                       && apt-cache search -n ^fonts- \
                         | awk '{{print $1}}' \
                         | grep -v fonts-mathematica \

--- a/pdf/ml_test/requirements.txt
+++ b/pdf/ml_test/requirements.txt
@@ -1,6 +1,6 @@
 -f https://download.pytorch.org/whl/torch_stable.html
-torch==1.8.0+cpu
-torchvision==0.9.0+cpu
+torch==1.13.1+cpu
+torchvision==0.14.1+cpu
 
 adabelief-pytorch
 matplotlib
@@ -9,4 +9,3 @@ pytest
 pytest-mock
 scipy
 tensorboard
-

--- a/pdf/ml_test/requirements.txt
+++ b/pdf/ml_test/requirements.txt
@@ -1,6 +1,6 @@
 -f https://download.pytorch.org/whl/torch_stable.html
-torch==1.13.1+cpu
-torchvision==0.14.1+cpu
+torch==2.0.1+cpu
+torchvision==0.15.2+cpu
 
 adabelief-pytorch
 matplotlib

--- a/pdf/parser-xpdf/config.json5
+++ b/pdf/parser-xpdf/config.json5
@@ -259,7 +259,7 @@
                     // XPDF takes down old binaries periodically; however, they
                     // maintain archives of old source. For parity with Safedocs
                     // program, build from source.
-                    'RUN apt-get update && apt-get install -y qt5-default',
+                    'RUN apt-get update && apt-get install -y qtbase5-dev qt5-qmake',
                     'RUN mkdir -p /opt/xpdf \
                         && cd /opt/xpdf \
                         && wget https://dl.xpdfreader.com/old/xpdf-4.02.tar.gz \


### PR DESCRIPTION
(and python to 3.10)

A previous version of this PR also updated mongo, but that wasn't necessary after all.