### PR TITLE
Add missing dask[distributed] dependency and fix click version

### DIFF
--- a/faw/pdf-observatory/requirements.txt
+++ b/faw/pdf-observatory/requirements.txt
@@ -1,7 +1,7 @@
 bokeh >= 2.1.1
 cachetools
-click==7.*
-dask[complete] == 2023.5.0
+click==8.*
+dask[complete,distributed] == 2023.5.0
 graphlib-backport==1.0.3  # Backport of py39+ graphlib stdlib module
 jupyter-server-proxy
 motor


### PR DESCRIPTION
`dask[distributed]` was missing from non-pdf distributions. Also, when installing dependencies during the build, pip complained about click 7 being incompatible with this version of dask, but proceeded anyway.